### PR TITLE
Add missing paren to fix link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To contribute to the English version of this book just use the issues and pull r
 
 ## Other versions
 
-Portuguese version: [https://github.com/soapdog/guia-rapido-firefox-os/](GitHub Repo) and [https://leanpub.com/guiarapidofirefoxos](Live book page)
+Portuguese version: [GitHub Repo](https://github.com/soapdog/guia-rapido-firefox-os/) and [Live book page](https://leanpub.com/guiarapidofirefoxos)
 
 ## License
 

--- a/basics.md
+++ b/basics.md
@@ -11,7 +11,7 @@ Looking at the big picture, a Firefox OS app is just a web page that has an icon
 
 ## The Application Manifest
 
-The [manifest]https://developer.mozilla.org/docs/Apps/Manifest) is a [JSON](http://json.org) file that describes aspects of an hosted web app. Usually this file is called **manifest.webapp** and lives next to your main HTML file that is usually called **index.html**.
+The [manifest](https://developer.mozilla.org/docs/Apps/Manifest) is a [JSON](http://json.org) file that describes aspects of an hosted web app. Usually this file is called **manifest.webapp** and lives next to your main HTML file that is usually called **index.html**.
 
 <<[Sample Manifest](code/sample_manifest.webapp)
 


### PR DESCRIPTION
Right now the "Basic Concepts" page says...
    The [manifest]https://developer.mozilla.org/docs/Apps/Manifest) 
...with broken markdown, resulting in brackets and the raw URL and paren being displayed.

This commit adds the missing paren to fix that.
